### PR TITLE
Fix communities filter text positioning

### DIFF
--- a/css/communities.css
+++ b/css/communities.css
@@ -13512,6 +13512,27 @@ div[id^=lconn_communities_catalog_widgets_RecommendationsBox_] a {
   margin-bottom: 0;
 }
 
+body.catalog input[type=text],
+body.catalog input[type=password] {
+  line-height: 1.5 !important;
+  background: none !important;
+  padding: 0 !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  font-size: 12.8px !important;
+  padding-right: 1rem !important;
+  padding-bottom: 0.375rem !important;
+  box-sizing: border-box !important;
+  height: auto !important;
+}
+
+#icCatalogFilter {
+  padding: 0 0 0 10px !important;
+  line-height: 2rem !important;
+  border-bottom: none !important;
+  box-shadow: none !important;
+}
+
 .lotusMain .lotusColLeft .lotusHeading {
   padding-left: 24px;
 }

--- a/scss/apps/communities/communitieslanding/_communitieslanding.scss
+++ b/scss/apps/communities/communitieslanding/_communitieslanding.scss
@@ -115,3 +115,19 @@ div[id^="lconn_communities_catalog_widgets_RecommendationsBox_"] {
     margin-bottom: 0;
   }
 }
+
+body.catalog input[type=text],
+body.catalog input[type=password] {
+  line-height: 1.5 !important;
+  background: none !important;
+  padding: 0 !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  font-size: 12.8px !important;
+  padding-right: 1rem !important;
+  padding-bottom: 0.375rem !important;
+  box-sizing: border-box !important;
+  height: auto !important;
+}
+
+#icCatalogFilter {padding: 0 0 0 10px !important; line-height: 2rem !important; border-bottom: none !important; box-shadow: none !important}


### PR DESCRIPTION
This fix properly centers text in the communities filter field on the Communities > Discover tab, and removes unwanted borders.

![image](https://user-images.githubusercontent.com/30048699/131393497-20c0f67a-2663-4eeb-956c-711cd8f4a2b6.png)

