### PR TITLE
fix drop area in community file upload dialog

### DIFF
--- a/css/communities.css
+++ b/css/communities.css
@@ -12274,10 +12274,6 @@ html.catalog-ui-updated .catalog .lotusMain .lotusColLeft:not(.wpthemeNarrow) > 
   position: relative;
 }
 
-#lconn_files_action_additem_2 {
-  box-sizing: border-box !important;
-}
-
 body.catalog #lotusColLeftContents .lotusSection .lotusSectionBody {
   padding: 0 24px !important;
   padding-left: calc((15px + 24px)) !important;
@@ -13531,6 +13527,10 @@ body.catalog input[type=password] {
   line-height: 2rem !important;
   border-bottom: none !important;
   box-shadow: none !important;
+}
+
+.lotusUploadFile .lotusDialog .lotusFormFieldRow td {
+  display: table-cell !important;
 }
 
 .lotusMain .lotusColLeft .lotusHeading {

--- a/scss/apps/communities/communitieslanding/_communitieslanding.scss
+++ b/scss/apps/communities/communitieslanding/_communitieslanding.scss
@@ -130,4 +130,11 @@ body.catalog input[type=password] {
   height: auto !important;
 }
 
+
 #icCatalogFilter {padding: 0 0 0 10px !important; line-height: 2rem !important; border-bottom: none !important; box-shadow: none !important}
+
+
+.lotusUploadFile .lotusDialog .lotusFormFieldRow td {
+  display: table-cell !important;
+}
+


### PR DESCRIPTION
The file drop area in the Community Files "Upload Files" dialog should look like the image below, not compressed horizontally and aligned left as it was previously.

![image](https://user-images.githubusercontent.com/30048699/132905597-8afc4c7c-3402-4793-8d75-98b7abad3778.png)
