### PR TITLE
fix warning box layout

### DIFF
--- a/css/communities.css
+++ b/css/communities.css
@@ -12274,6 +12274,10 @@ html.catalog-ui-updated .catalog .lotusMain .lotusColLeft:not(.wpthemeNarrow) > 
   position: relative;
 }
 
+#lconn_files_action_additem_2 {
+  box-sizing: border-box !important;
+}
+
 body.catalog #lotusColLeftContents .lotusSection .lotusSectionBody {
   padding: 0 24px !important;
   padding-left: calc((15px + 24px)) !important;
@@ -13695,6 +13699,12 @@ body.catalog input[type=password] {
 }
 #newCommunityForm #communitiesAddButton {
   display: none !important;
+}
+
+#internalOnlyPermanentWarning > div {
+  position: relative;
+  right: 585px;
+  width: 500px;
 }
 
 #selectCommForm #communityTypeAhead {

--- a/scss/apps/communities/communitieslanding/_createnew.scss
+++ b/scss/apps/communities/communitieslanding/_createnew.scss
@@ -130,6 +130,12 @@
   }
 }
 
+#internalOnlyPermanentWarning > div {
+    position: relative;
+    right: 585px;
+    width: 500px;
+}
+
 #selectCommForm {
   #communityTypeAhead {
     padding-left: 2rem !important;


### PR DESCRIPTION
When selecting an Open Community, the warning box about not being able to change that was off center. Testing done in Firefox and Chrome, box is now left-aligned.

Steps to check the fix:

    Create New Community

    Choose Public

    Warning box about unable to change from Public afterwards is left aligned.

![image](https://user-images.githubusercontent.com/30048699/133452392-99aae1fd-52af-4925-b2b4-5c25da0dd316.png)
